### PR TITLE
add script to check component exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # Toniq Labs Design System
 
-Yay design!
+Reusable components for Toniq Lab's websites. All components are currently React only.
+
+Package on NPM: https://www.npmjs.com/package/@toniq-labs/design-system
+Storybook on GitHub Pages: https://toniq-labs.github.io/toniq-labs-design-system
+
+# Usage
+
+```bash
+npm i @toniq-labs/design-system
+```
 
 # Dev
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
                 "babel-loader": "8.2.5",
                 "http-server": "14.1.0",
                 "npm-force-resolutions": "0.0.10",
+                "prettier": "2.6.2",
                 "react": "18.1.0",
                 "react-dom": "18.1.0",
                 "rollup": "2.71.1",
@@ -4279,6 +4280,18 @@
                 }
             }
         },
+        "node_modules/@storybook/addon-docs/node_modules/prettier": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
+            "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
+            "dev": true,
+            "bin": {
+                "prettier": "bin-prettier.js"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
         "node_modules/@storybook/addon-essentials": {
             "version": "6.4.22",
             "resolved": "https://registry.npmjs.org/@storybook/addon-essentials/-/addon-essentials-6.4.22.tgz",
@@ -5325,6 +5338,18 @@
                 "url": "https://opencollective.com/storybook"
             }
         },
+        "node_modules/@storybook/csf-tools/node_modules/prettier": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
+            "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
+            "dev": true,
+            "bin": {
+                "prettier": "bin-prettier.js"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
         "node_modules/@storybook/instrumenter": {
             "version": "6.4.22",
             "resolved": "https://registry.npmjs.org/@storybook/instrumenter/-/instrumenter-6.4.22.tgz",
@@ -5794,6 +5819,18 @@
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0",
                 "react-dom": "^16.8.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@storybook/source-loader/node_modules/prettier": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
+            "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
+            "dev": true,
+            "bin": {
+                "prettier": "bin-prettier.js"
+            },
+            "engines": {
+                "node": ">=10.13.0"
             }
         },
         "node_modules/@storybook/store": {
@@ -11245,15 +11282,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/execa/node_modules/shebang-regex": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/execa/node_modules/which": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -13260,18 +13288,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/http-server/node_modules/iconv-lite": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-            "dev": true,
-            "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/http-server/node_modules/supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -13282,18 +13298,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/http-server/node_modules/whatwg-encoding": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
-            "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
-            "dev": true,
-            "dependencies": {
-                "iconv-lite": "0.6.3"
-            },
-            "engines": {
-                "node": ">=12"
             }
         },
         "node_modules/https-browserify": {
@@ -17320,7 +17324,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
             "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-            "dev": true,
             "dependencies": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
             },
@@ -19680,15 +19683,18 @@
             }
         },
         "node_modules/prettier": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
-            "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+            "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
             "dev": true,
             "bin": {
                 "prettier": "bin-prettier.js"
             },
             "engines": {
                 "node": ">=10.13.0"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
         "node_modules/prettier-plugin-jsdoc": {
@@ -20129,7 +20135,6 @@
             "version": "18.1.0",
             "resolved": "https://registry.npmjs.org/react/-/react-18.1.0.tgz",
             "integrity": "sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==",
-            "dev": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -20190,7 +20195,6 @@
             "version": "18.1.0",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.1.0.tgz",
             "integrity": "sha512-fU1Txz7Budmvamp7bshe4Zi32d0ll7ect+ccxNu9FlObT605GOEB8BfO4tmRJ39R5Zj831VCpvQ05QPBW5yb+w==",
-            "dev": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.22.0"
@@ -20277,8 +20281,7 @@
         "node_modules/react-is": {
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-            "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-            "dev": true
+            "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
         },
         "node_modules/react-popper": {
             "version": "2.3.0",
@@ -21475,7 +21478,6 @@
             "version": "0.22.0",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.22.0.tgz",
             "integrity": "sha512-6QAm1BgQI88NPYymgGQLCZgvep4FyePDWFpXVK+zNSUgHwlqpJy8VEh8Et0KxTACS4VWwMousBElAZOH9nkkoQ==",
-            "dev": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             }
@@ -24329,21 +24331,6 @@
             },
             "engines": {
                 "node": ">=12"
-            }
-        },
-        "node_modules/virmator/node_modules/prettier": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
-            "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
-            "dev": true,
-            "bin": {
-                "prettier": "bin-prettier.js"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            },
-            "funding": {
-                "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
         "node_modules/vm-browserify": {
@@ -28106,7 +28093,8 @@
             "version": "1.6.22",
             "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.22.tgz",
             "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "@mdx-js/util": {
             "version": "1.6.22",
@@ -28415,6 +28403,14 @@
                 "remark-slug": "^6.0.0",
                 "ts-dedent": "^2.0.0",
                 "util-deprecate": "^1.0.2"
+            },
+            "dependencies": {
+                "prettier": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
+                    "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
+                    "dev": true
+                }
             }
         },
         "@storybook/addon-essentials": {
@@ -29139,6 +29135,14 @@
                 "prettier": ">=2.2.1 <=2.3.0",
                 "regenerator-runtime": "^0.13.7",
                 "ts-dedent": "^2.0.0"
+            },
+            "dependencies": {
+                "prettier": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
+                    "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
+                    "dev": true
+                }
             }
         },
         "@storybook/instrumenter": {
@@ -29474,6 +29478,14 @@
                 "lodash": "^4.17.21",
                 "prettier": ">=2.2.1 <=2.3.0",
                 "regenerator-runtime": "^0.13.7"
+            },
+            "dependencies": {
+                "prettier": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
+                    "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
+                    "dev": true
+                }
             }
         },
         "@storybook/store": {
@@ -29699,7 +29711,8 @@
             "version": "14.1.1",
             "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.1.1.tgz",
             "integrity": "sha512-XrjH/iEUqNl9lF2HX9YhPNV7Amntkcnpw0Bo1KkRzowNDcgSN9i0nm4Q8Oi5wupgdfPaJNMAWa61A+voD6Kmwg==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "@tootallnate/once": {
             "version": "1.1.2",
@@ -30400,7 +30413,8 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "acorn-walk": {
             "version": "7.2.0",
@@ -30474,13 +30488,15 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
             "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "ajv-keywords": {
             "version": "3.5.2",
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
             "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "ansi-align": {
             "version": "3.0.1",
@@ -31231,7 +31247,8 @@
             "version": "0.3.8",
             "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.8.tgz",
             "integrity": "sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "babel-plugin-polyfill-corejs2": {
             "version": "0.3.1",
@@ -33883,12 +33900,6 @@
                         "shebang-regex": "^1.0.0"
                     }
                 },
-                "shebang-regex": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-                    "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-                    "dev": true
-                },
                 "which": {
                     "version": "1.3.1",
                     "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -35439,15 +35450,6 @@
                         "whatwg-encoding": "^2.0.0"
                     }
                 },
-                "iconv-lite": {
-                    "version": "0.6.3",
-                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-                    "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-                    "dev": true,
-                    "requires": {
-                        "safer-buffer": ">= 2.1.2 < 3.0.0"
-                    }
-                },
                 "supports-color": {
                     "version": "7.2.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -35455,15 +35457,6 @@
                     "dev": true,
                     "requires": {
                         "has-flag": "^4.0.0"
-                    }
-                },
-                "whatwg-encoding": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
-                    "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
-                    "dev": true,
-                    "requires": {
-                        "iconv-lite": "0.6.3"
                     }
                 }
             }
@@ -37181,7 +37174,8 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
             "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "jest-regex-util": {
             "version": "26.0.0",
@@ -38315,7 +38309,8 @@
                     "version": "7.5.7",
                     "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
                     "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
-                    "dev": true
+                    "dev": true,
+                    "requires": {}
                 }
             }
         },
@@ -38497,7 +38492,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
             "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-            "dev": true,
             "requires": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
             }
@@ -38686,7 +38680,8 @@
             "version": "7.1.7",
             "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.7.tgz",
             "integrity": "sha512-VI3TyyHlGkO8uFle0IOibzpO1c1iJDcXcS/zBrQrXQQvJ2tpdwVzVZ7XdKsyRz1NdRmre4dqQkMZzUHaKIG/1w==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "md5.js": {
             "version": "1.3.5",
@@ -40233,9 +40228,9 @@
             "dev": true
         },
         "prettier": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
-            "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+            "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
             "dev": true
         },
         "prettier-plugin-jsdoc": {
@@ -40284,7 +40279,8 @@
             "version": "2.3.4",
             "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-2.3.4.tgz",
             "integrity": "sha512-R8o23sf5iVL/U71h9SFUdhdOEPsi3nm42FD/oDYIZ2PQa4TNWWuWecxln6jlIQzpZTDMUeO1NicJP6lLn2TtRw==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "prettier-plugin-packagejson": {
             "version": "2.2.17",
@@ -40578,7 +40574,6 @@
             "version": "18.1.0",
             "resolved": "https://registry.npmjs.org/react/-/react-18.1.0.tgz",
             "integrity": "sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==",
-            "dev": true,
             "requires": {
                 "loose-envify": "^1.1.0"
             }
@@ -40587,7 +40582,8 @@
             "version": "5.5.1",
             "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.5.1.tgz",
             "integrity": "sha512-M1TJH2X3RXEt12sWkpa6hLc/bbYS0H6F4rIqjQZ+RxNBstpY67d9TrFXtqdZwhpmBXcCwEi7stKqFue3ZRkiOg==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "react-docgen": {
             "version": "5.4.0",
@@ -40619,13 +40615,13 @@
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz",
             "integrity": "sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "react-dom": {
             "version": "18.1.0",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.1.0.tgz",
             "integrity": "sha512-fU1Txz7Budmvamp7bshe4Zi32d0ll7ect+ccxNu9FlObT605GOEB8BfO4tmRJ39R5Zj831VCpvQ05QPBW5yb+w==",
-            "dev": true,
             "requires": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.22.0"
@@ -40693,8 +40689,7 @@
         "react-is": {
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-            "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-            "dev": true
+            "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
         },
         "react-popper": {
             "version": "2.3.0",
@@ -41371,7 +41366,8 @@
             "version": "2.2.4",
             "resolved": "https://registry.npmjs.org/rollup-plugin-peer-deps-external/-/rollup-plugin-peer-deps-external-2.2.4.tgz",
             "integrity": "sha512-AWdukIM1+k5JDdAqV/Cxd+nejvno2FVLVeZ74NKggm3Q5s9cbbcOgUPGdbxPi4BXu7xGaZ8HG12F+thImYu/0g==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "rollup-plugin-terser": {
             "version": "7.0.2",
@@ -41622,7 +41618,6 @@
             "version": "0.22.0",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.22.0.tgz",
             "integrity": "sha512-6QAm1BgQI88NPYymgGQLCZgvep4FyePDWFpXVK+zNSUgHwlqpJy8VEh8Et0KxTACS4VWwMousBElAZOH9nkkoQ==",
-            "dev": true,
             "requires": {
                 "loose-envify": "^1.1.0"
             }
@@ -43624,13 +43619,15 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
             "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "use-isomorphic-layout-effect": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
             "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "use-latest": {
             "version": "1.2.1",
@@ -43846,12 +43843,6 @@
                         "jsonfile": "^6.0.1",
                         "universalify": "^2.0.0"
                     }
-                },
-                "prettier": {
-                    "version": "2.6.2",
-                    "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
-                    "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
-                    "dev": true
                 }
             }
         },
@@ -44321,7 +44312,8 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/webpack-filter-warnings-plugin/-/webpack-filter-warnings-plugin-1.2.1.tgz",
             "integrity": "sha512-Ez6ytc9IseDMLPo0qCuNNYzgtUl8NovOqjIq4uAU8LTD4uoa1w1KpZyyzFtLTEMZpkkOkLfL9eN+KGYdk1Qtwg==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "webpack-hot-middleware": {
             "version": "2.25.1",
@@ -44522,7 +44514,8 @@
             "version": "8.6.0",
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.6.0.tgz",
             "integrity": "sha512-AzmM3aH3gk0aX7/rZLYvjdvZooofDu3fFOzGqcSnQ1tOcTWwhM/o+q++E8mAyVVIyUdajrkzWUGftaVSDLn1bw==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "xdg-basedir": {
             "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "internet computer",
         "ic"
     ],
-    "homepage": "https://github.com/Toniq-Labs/toniq-labs-design-system#readme",
+    "homepage": "https://toniq-labs.github.io/toniq-labs-design-system",
     "bugs": {
         "url": "https://github.com/Toniq-Labs/toniq-labs-design-system/issues"
     },

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
         "babel-loader": "8.2.5",
         "http-server": "14.1.0",
         "npm-force-resolutions": "0.0.10",
+        "prettier": "2.6.2",
         "react": "18.1.0",
         "react-dom": "18.1.0",
         "rollup": "2.71.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "types": "dist/index.d.ts",
     "scripts": {
         "build": "rm -rf dist && rollup -c",
+        "check-exports": "cd scripts && npm run check-exports",
         "format": "virmator format --no-write-config",
         "preinstall": "npm-force-resolutions",
         "prepublishOnly": "npm run test:full && ts-node scripts/src/publishing.ts prepublish && npm run build",
@@ -43,7 +44,7 @@
         "storybook:build": "build-storybook --output-dir .storybook-dist",
         "storybook:preview": "npm run storybook:build && http-server .storybook-dist",
         "test": "virmator test --no-write-config",
-        "test:full": "npm test && npm run spellcheck && npm run format check && npm run build && npm run storybook:build && cd scripts && npm run check-exports"
+        "test:full": "npm test && npm run spellcheck && npm run format check && npm run build && npm run storybook:build && npm run check-exports"
     },
     "resolutions": {
         "glob-parent": "6.0.2",

--- a/scripts/src/common/format.ts
+++ b/scripts/src/common/format.ts
@@ -5,7 +5,7 @@ import * as importedRepoConfig from '../../../.prettierrc.js';
 
 const repoConfig: PrettierOptions = importedRepoConfig as PrettierOptions;
 
-export function formatText(text: string, filePath: string): string {
+export function formatCode(text: string, filePath: string): string {
     return prettierFormat(text, {
         ...repoConfig,
         filepath: filePath,

--- a/scripts/src/publishing.ts
+++ b/scripts/src/publishing.ts
@@ -9,7 +9,7 @@
 import {readFile, writeFile} from 'fs/promises';
 import {join} from 'path';
 import {repoRootDir} from './common/file-paths';
-import {formatText} from './common/format';
+import {formatCode} from './common/format';
 
 const packageJsonPath = join(repoRootDir, 'package.json');
 const preInstallScript = 'npx npm-force-resolutions';
@@ -20,7 +20,7 @@ async function getPackageJsonObject() {
 }
 
 async function writePackageJson(packageJsonContents: any) {
-    const newFileContents = formatText(
+    const newFileContents = formatCode(
         JSON.stringify(packageJsonContents, null, 4),
         packageJsonPath,
     );

--- a/scripts/src/update-all-exports.ts
+++ b/scripts/src/update-all-exports.ts
@@ -1,15 +1,41 @@
-import {awaitedForEach} from 'augment-vir/dist';
-import {errorIfFailure, parseUpdateExportsArgs, UpdateExportsConfig} from './common/update-exports';
+import {extractErrorMessage} from 'augment-vir';
+import {
+    NotUpToDateError,
+    parseUpdateExportsArgs,
+    UpdateExportsConfig,
+} from './common/update-exports';
+import {updateComponentExports} from './update-component-exports';
 import {updateIconExports} from './update-icon-exports';
 
-const updateExportsFunctions: UpdateExportsConfig[] = [updateIconExports];
+const updateExportsConfigs: UpdateExportsConfig[] = [
+    updateIconExports,
+    updateComponentExports,
+];
 
 async function main() {
     const args = parseUpdateExportsArgs();
-    await awaitedForEach(updateExportsFunctions, async (updateExports) => {
-        const result = await updateExports.executor(args);
-        errorIfFailure(updateIconExports, result);
-    });
+    const didSucceed: boolean[] = await Promise.all(
+        updateExportsConfigs.map(async (updateExportsConfig): Promise<boolean> => {
+            try {
+                await updateExportsConfig.executor(args);
+                return true;
+            } catch (caughtError) {
+                if (caughtError instanceof NotUpToDateError) {
+                    const errorMessage = extractErrorMessage(caughtError);
+                    console.error(errorMessage);
+                    return false;
+                } else {
+                    throw caughtError;
+                }
+            }
+        }),
+    );
+
+    const someFailed = didSucceed.some((result) => !result);
+
+    if (someFailed) {
+        process.exit(1);
+    }
 }
 
 if (require.main === module) {

--- a/scripts/src/update-component-exports.ts
+++ b/scripts/src/update-component-exports.ts
@@ -1,0 +1,83 @@
+import {toPosixPath} from 'augment-vir/dist/node-only';
+import {existsSync} from 'fs';
+import {readdir, stat} from 'fs/promises';
+import {join, relative} from 'path';
+import {srcDir} from './common/file-paths';
+import {
+    UpdateExportsArgs,
+    UpdateExportsConfig,
+    updateExportsMain,
+    writeOrCheckFromArgs,
+} from './common/update-exports';
+
+const componentsDir = join(srcDir, 'components');
+const componentIndexPath = join(componentsDir, 'index.tsx');
+
+async function getComponentFilePaths(): Promise<string[]> {
+    const allComponentDirChildrenWithStats = await Promise.all(
+        (
+            await readdir(componentsDir)
+        ).map(async (childName) => {
+            const childFullPath = join(componentsDir, childName);
+            const stats = await stat(childFullPath);
+
+            return {
+                stats,
+                childName,
+            };
+        }),
+    );
+    const allComponentDirectoryNames = allComponentDirChildrenWithStats
+        .filter((child) => {
+            return child.stats.isDirectory();
+        })
+        .map((child) => child.childName);
+    const allComponentFilePaths = allComponentDirectoryNames.map((componentDir) => {
+        const fileName = `${componentDir}.tsx`;
+        return join(componentsDir, componentDir, fileName);
+    });
+    return allComponentFilePaths;
+}
+
+async function verifyComponentFilePaths(filePaths: string[]): Promise<void> {
+    await Promise.all(
+        filePaths.map(async (filePath) => {
+            if (!existsSync(filePath)) {
+                throw new Error(`Component file "${filePath}" does not exist.`);
+            }
+            if (!(await stat(filePath)).isFile()) {
+                throw new Error(`Component file "${filePath}" is not a file.`);
+            }
+        }),
+    );
+}
+
+function generateComponentExports(filePaths: string[]): string {
+    const exportLines = filePaths.map((filePath) => {
+        const relativePath = relative(componentsDir, filePath).replace(/\.tsx?$/, '');
+
+        return `export * from './${toPosixPath(relativePath)}';`;
+    });
+    return exportLines.join('\n');
+}
+
+export const updateComponentExports: UpdateExportsConfig = {
+    executor: async (inputs: UpdateExportsArgs): Promise<void> => {
+        const componentFilePaths = await getComponentFilePaths();
+        await verifyComponentFilePaths(componentFilePaths);
+
+        await writeOrCheckFromArgs(
+            componentIndexPath,
+            generateComponentExports(componentFilePaths),
+            inputs,
+            __filename,
+        );
+    },
+};
+
+if (require.main === module) {
+    updateExportsMain(componentIndexPath, updateComponentExports).catch((error) => {
+        console.error(error);
+        process.exit(1);
+    });
+}

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "noEmit": true,
         "rootDir": "src"
     },
     "extends": "../tsconfig-base.json"

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -12,20 +12,12 @@
         "noImplicitReturns": true,
         "noImplicitThis": true,
         "noUncheckedIndexedAccess": true,
-        "outDir": "dist",
-        "rootDir": "src",
         "skipDefaultLibCheck": true,
         "skipLibCheck": true,
         "strict": true,
         "target": "ESNext",
         "useUnknownInCatchVariables": true
     },
-    "exclude": [
-        "dist",
-        "node_modules",
-        "separate-configs",
-        "test-files"
-    ],
     "ts-node": {
         "compilerOptions": {
             "module": "CommonJS"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,16 @@
         "declarationDir": "types",
         "jsx": "react",
         "module": "ESNext",
+        "outDir": "dist",
+        "rootDir": "src",
         "sourceMap": true
     },
-    "exclude": ["scripts"],
+    "exclude": [
+        ".storybook-dist",
+        ".virmator",
+        "graphics",
+        "scripts",
+        "storybook"
+    ],
     "extends": "./tsconfig-base.json"
 }


### PR DESCRIPTION
- add script to update and verify component exports to ensure we are always exporting all the components
- explicitly set `prettier` version, so it can parse the latest TypeScript code, rather than depending on child dependencies
- update some documentation links