### PR TITLE
support text-only toggle button with icon

### DIFF
--- a/src/elements/toniq-toggle-button/toniq-toggle-button.element.ts
+++ b/src/elements/toniq-toggle-button/toniq-toggle-button.element.ts
@@ -1,9 +1,12 @@
 import {randomString} from 'augment-vir';
-import {css, defineElementEvent, html} from 'element-vir';
+import {assign, css, defineElementEvent, html} from 'element-vir';
+import {ToniqSvg} from '../../icons';
+import {interactionDuration} from '../../styles';
 import {applyBackgroundAndForeground, toniqColors} from '../../styles/colors';
 import {toniqFontStyles} from '../../styles/fonts';
 import {noUserSelect} from '../../styles/user-select';
 import {defineToniqElement} from '../define-toniq-element';
+import {ToniqIcon} from '../toniq-icon/toniq-icon.element';
 
 export const ToniqToggleButton = defineToniqElement({
     initCallback: ({setProps}) => {
@@ -13,6 +16,7 @@ export const ToniqToggleButton = defineToniqElement({
     props: {
         text: '',
         active: false,
+        icon: undefined as undefined | ToniqSvg,
         inputId: '',
     },
     events: {
@@ -22,35 +26,73 @@ export const ToniqToggleButton = defineToniqElement({
         :host {
             ${toniqFontStyles.boldParagraphFont};
             ${noUserSelect};
-            display: inline-block;
+            display: inline-flex;
+            vertical-align: middle;
         }
 
         label {
-            display: inline-block;
+            display: inline-flex;
         }
 
-        span {
+        .wrapper {
             border: 0;
             display: inline-flex;
             cursor: pointer;
             font: inherit;
+            align-items: center;
 
             -webkit-tap-highlight-color: transparent;
             border-radius: 8px;
 
             ${applyBackgroundAndForeground(toniqColors.accentSecondary)};
-            padding: 4px 12px;
+            transition: ${interactionDuration};
+        }
+
+        .text-wrapper {
+            margin: 4px 12px;
+            margin-left: 0;
+        }
+
+        .icon-wrapper {
+            margin-left: 12px;
         }
 
         input {
             display: none;
         }
 
-        .active span {
+        .active .wrapper {
             ${applyBackgroundAndForeground(toniqColors.accentPrimary)};
+        }
+
+        :host(.toniq-toggle-button-text-only) .wrapper {
+            ${applyBackgroundAndForeground(toniqColors.pagePrimary)};
+            background: none;
+        }
+        :host(.toniq-toggle-button-text-only) .active .wrapper {
+            ${applyBackgroundAndForeground(toniqColors.pageInteraction)};
+            background: none;
+        }
+        :host(.toniq-toggle-button-text-only) .text-wrapper {
+            margin-right: 8px;
+        }
+        :host(.toniq-toggle-button-text-only) .icon-wrapper {
+            margin-left: 8px;
+        }
+
+        ${ToniqIcon} {
+            margin-right: 8px;
         }
     `,
     renderCallback: ({props, dispatch, events, setProps}) => {
+        const iconTemplate = props.icon
+            ? html`
+                <${ToniqIcon}
+                    ${assign(ToniqIcon.props.icon, props.icon)}
+                ></${ToniqIcon}>
+            `
+            : '';
+
         return html`
             <label class=${props.active ? 'active' : ''} for=${props.inputId}>
                 <input
@@ -63,7 +105,10 @@ export const ToniqToggleButton = defineToniqElement({
                         dispatch(new events.activeChange(isActive));
                     }}
                 />
-                <span>${props.text}</span>
+                <span class="wrapper">
+                    <span class="icon-wrapper">${iconTemplate}</span>
+                    <span class="text-wrapper">${props.text}</span>
+                </span>
             </label>
         `;
     },

--- a/src/elements/toniq-toggle-button/toniq-toggle-button.story.tsx
+++ b/src/elements/toniq-toggle-button/toniq-toggle-button.story.tsx
@@ -1,6 +1,7 @@
 import {action} from '@storybook/addon-actions';
 import {ArgTypes, ComponentMeta} from '@storybook/react';
 import React from 'react';
+import {allIconsByCategory, Rocket24Icon} from '../../icons';
 import {toniqFontStyles} from '../../styles';
 import {cssToReactStyleObject} from '../../styles/css-to-react';
 import {ToniqToggleButton} from '../react-components';
@@ -14,6 +15,27 @@ const toggleButtonStoryControls = (<SpecificArgsGeneric extends ArgTypes>(
             disable: true,
         },
     },
+    icon: {
+        table: {
+            disable: true,
+        },
+    },
+    iconControl: {
+        name: '24px Icon',
+        control: 'select',
+        options: [
+            'None',
+            ...allIconsByCategory['core-24'].map((icon) => icon.iconName),
+        ],
+    },
+    hostClass: {
+        name: 'Host Class',
+        control: 'select',
+        options: [
+            'None',
+            'toniq-toggle-button-text-only',
+        ],
+    },
     active: {
         table: {
             disable: true,
@@ -24,10 +46,10 @@ const toggleButtonStoryControls = (<SpecificArgsGeneric extends ArgTypes>(
             disable: true,
         },
     },
-    activeInput: {
+    activeControl: {
         name: 'Active',
     },
-    textInput: {
+    textControl: {
         name: 'Text',
         control: 'text',
     },
@@ -38,8 +60,10 @@ const componentStoryMeta: ComponentMeta<typeof ToniqToggleButton> = {
     component: ToniqToggleButton,
     argTypes: toggleButtonStoryControls,
     args: {
-        textInput: 'Custom text here',
-        activeInput: false,
+        textControl: 'Custom text here',
+        activeControl: false,
+        iconControl: 'None',
+        hostClass: 'None',
     },
 };
 
@@ -52,28 +76,51 @@ function handleChange(event: typeof NativeToniqToggleButton.events.activeChange)
 export const mainStory = (
     controls: Record<keyof typeof toggleButtonStoryControls, string | boolean>,
 ) => {
-    const customText = String(controls.textInput);
-    const isActive = !!controls.activeInput;
+    const customText = String(controls.textControl);
+    const isActive = !!controls.activeControl;
+    const customIcon = allIconsByCategory['core-24'].find(
+        (icon) => icon.iconName === controls.iconControl,
+    );
+
+    function generateSection(active: boolean) {
+        const title = `${active ? 'Active' : 'Inactive'} by default`;
+        return (
+            <>
+                <h3
+                    style={{
+                        ...cssToReactStyleObject(toniqFontStyles.h3Font),
+                    }}
+                >
+                    {title}
+                </h3>
+                <section style={{display: 'flex', gap: '8px'}}>
+                    <ToniqToggleButton
+                        onActiveChange={handleChange}
+                        text="Toggle Me"
+                        active={active}
+                    />
+                    <ToniqToggleButton
+                        className="toniq-toggle-button-text-only"
+                        onActiveChange={handleChange}
+                        text="Text Only"
+                        active={active}
+                    />
+                    <ToniqToggleButton
+                        className="toniq-toggle-button-text-only"
+                        onActiveChange={handleChange}
+                        icon={Rocket24Icon}
+                        text="With Icon"
+                        active={active}
+                    />
+                </section>
+            </>
+        );
+    }
 
     return (
         <>
-            <h3
-                style={{
-                    ...cssToReactStyleObject(toniqFontStyles.h3Font),
-                }}
-            >
-                Inactive by default
-            </h3>
-            <ToniqToggleButton onActiveChange={handleChange} text="Toggle Me" />
-
-            <h3
-                style={{
-                    ...cssToReactStyleObject(toniqFontStyles.h3Font),
-                }}
-            >
-                Active by default
-            </h3>
-            <ToniqToggleButton onActiveChange={handleChange} text="Toggle Me" active />
+            {generateSection(false)}
+            {generateSection(true)}
 
             <h3
                 style={{
@@ -82,7 +129,13 @@ export const mainStory = (
             >
                 Custom Inputs
             </h3>
-            <ToniqToggleButton onActiveChange={handleChange} text={customText} active={isActive} />
+            <ToniqToggleButton
+                className={controls.hostClass}
+                onActiveChange={handleChange}
+                icon={customIcon}
+                text={customText}
+                active={isActive}
+            />
         </>
     );
 };


### PR DESCRIPTION
Add text-with icon only toggle button style:
![toggle-button-story-with-text-only-support](https://user-images.githubusercontent.com/1205860/172004529-f297cb46-f21c-460e-ba96-a6e742a8b5fe.png)

Resolve #11 