### PR TITLE
Add keypress event on Toniq Input

### DIFF
--- a/src/elements/toniq-input/toniq-input.element.ts
+++ b/src/elements/toniq-input/toniq-input.element.ts
@@ -107,6 +107,7 @@ export const ToniqInput = defineToniqElement<{
          * that was blocked out of programmatic "value" property assignments.
          */
         inputBlocked: defineElementEvent<string>(),
+        keyPress: defineElementEvent<string>(),
     },
     styles: css`
         :host {
@@ -241,6 +242,9 @@ export const ToniqInput = defineToniqElement<{
                         if (beforeChangeText !== finalText) {
                             dispatch(new events.valueChange(finalText));
                         }
+                    })}
+                    ${listen('keypress', (event: KeyboardEvent) => {
+                        dispatch(new events.keyPress(event.key || event.keyCode));
                     })}
                     placeholder=${inputs.placeholder}
                 />

--- a/src/elements/toniq-input/toniq-input.element.ts
+++ b/src/elements/toniq-input/toniq-input.element.ts
@@ -108,7 +108,7 @@ export const ToniqInput = defineToniqElement<{
          */
         inputBlocked: defineElementEvent<string>(),
         /** Fires when a key is pressed. Useful for triggering events like on key Enter and other keys. */
-        keyPress: defineElementEvent<string>(),
+        keyPress: defineElementEvent<string | number>(),
     },
     styles: css`
         :host {

--- a/src/elements/toniq-input/toniq-input.element.ts
+++ b/src/elements/toniq-input/toniq-input.element.ts
@@ -107,7 +107,7 @@ export const ToniqInput = defineToniqElement<{
          * that was blocked out of programmatic "value" property assignments.
          */
         inputBlocked: defineElementEvent<string>(),
-        /** Fires when a key is press. Useful for triggering events like on key Enter and other keys. */
+        /** Fires when a key is pressed. Useful for triggering events like on key Enter and other keys. */
         keyPress: defineElementEvent<string>(),
     },
     styles: css`

--- a/src/elements/toniq-input/toniq-input.element.ts
+++ b/src/elements/toniq-input/toniq-input.element.ts
@@ -107,6 +107,7 @@ export const ToniqInput = defineToniqElement<{
          * that was blocked out of programmatic "value" property assignments.
          */
         inputBlocked: defineElementEvent<string>(),
+        /** Fires when a key is press. Useful for triggering events like on key Enter and other keys. */
         keyPress: defineElementEvent<string>(),
     },
     styles: css`

--- a/src/elements/toniq-input/toniq-input.story.tsx
+++ b/src/elements/toniq-input/toniq-input.story.tsx
@@ -73,6 +73,18 @@ export const mainStory = (controls: Record<keyof typeof inputStoryControls, stri
                 <ToniqInput
                     onValueChange={handleEventAsAction}
                     onInputBlocked={handleEventAsAction}
+                    onKeyPress={handleEventAsAction}
+                    value="on keypress"
+                />
+                <ToniqInput
+                    onValueChange={handleEventAsAction}
+                    onInputBlocked={handleEventAsAction}
+                    onKeyPress={handleEventAsAction}
+                    value="with value"
+                />
+                <ToniqInput
+                    onValueChange={handleEventAsAction}
+                    onInputBlocked={handleEventAsAction}
                     placeholder="with placeholder"
                     value=""
                 />


### PR DESCRIPTION
Add keypress event. Fires when a key is pressed. Useful for triggering events like on key Enter and other keys.